### PR TITLE
moving to transformers version from pypi

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ requirements:
 - accelerate
 - bitsandbytes
 - einops
-- git+https://github.com/huggingface/transformers.git
+- transformers
 - faker
 - math0
 - safetensors


### PR DESCRIPTION
chesterton's fence suggests this was pinned to github for a reason, but this seems to now conflict with `huggingface-hub==0.16.2` required by tuss (https://github.com/basetenlabs/truss/blob/main/truss/templates/server/requirements.txt)